### PR TITLE
Avoid unnecessary KNOWS reverse relationship

### DIFF
--- a/src/appConfigs/schema.ts
+++ b/src/appConfigs/schema.ts
@@ -205,11 +205,6 @@ export const typeDefs = gql`
         WITH apoc.text.join([$input.yyyy, $input.mm, $input.dd], '-') AS dateFormat
         WITH date(dateFormat) AS logDate, dateFormat
 
-        // Higher
-        MATCH (p1:Person {uid: $input.fromUid})
-        MATCH (p2:Person {uid: $input.toUid})
-        MERGE (p1)-[:KNOWS]->(p2)
-
         // Logs
         WITH apoc.text.join(['log', $input.fromUid], '_') AS fromLogId, logDate, dateFormat
         WITH apoc.text.join(['log', $input.toUid], '_') AS toLogId, fromLogId, logDate, dateFormat


### PR DESCRIPTION
KNOWS relationship is inserted in two places. Once in CreateKnows and another in LogContact. Not needed in LogContact.